### PR TITLE
port to aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 libc = "0.2.4"
-nix = "0.4.2"
+nix = "0.5.1"
 
 [dev-dependencies]
 argparse = "0.2.1"

--- a/src/child.rs
+++ b/src/child.rs
@@ -80,7 +80,7 @@ pub unsafe fn child_after_clone(child: &ChildInfo) -> ! {
     }
 
     for &(nstype, fd) in child.setns_namespaces {
-        if libc::setns(fd, nstype as i32) != 0 {
+        if libc::setns(fd, nstype.bits()) != 0 {
             fail(Err::SetNs, epipe);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use std::collections::HashMap;
 
 use nix::sys::signal::{SigNum, SIGKILL};
-use libc::{uid_t, gid_t};
+use libc::{uid_t, gid_t, c_int};
 
 use idmap::{UidMap, GidMap};
 use namespace::Namespace;
@@ -17,7 +17,7 @@ pub struct Config {
     pub gid: Option<gid_t>,
     pub supplementary_gids: Option<Vec<gid_t>>,
     pub id_maps: Option<(Vec<UidMap>, Vec<GidMap>)>,
-    pub namespaces: u32,
+    pub namespaces: c_int,
     pub setns_namespaces: HashMap<Namespace, Closing>,
     pub restore_sigmask: bool,
     pub make_group_leader: bool,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -134,7 +134,7 @@ impl Command {
         -> &mut Command
     {
         for ns in iter {
-            self.config.namespaces |= ns.to_clone_flag();
+            self.config.namespaces |= ns.to_clone_flag().bits();
         }
         self
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -65,7 +65,7 @@ pub enum Namespace {
 impl Namespace {
     /// Convert namespace to a clone flag passed to syscalls
     // TODO(tailhook) should this method be private?
-    pub fn to_clone_flag(&self) -> u32 {
+    pub fn to_clone_flag(&self) -> consts::CloneFlags {
         match *self {
             Namespace::Mount => consts::CLONE_NEWNS,
             Namespace::Uts => consts::CLONE_NEWUTS,

--- a/src/run.rs
+++ b/src/run.rs
@@ -201,7 +201,7 @@ impl Command {
         let mut wakeup = Some(wakeup);
         let mut wakeup_rd = Some(wakeup_rd);
         let mut errpipe_wr = Some(errpipe_wr);
-        let flags = self.config.namespaces | SIGCHLD as u32;
+        let flags = self.config.namespaces | SIGCHLD;
         let args_slice = &c_args[..];
         let environ_slice = &c_environ[..];
         // We transform all hashmaps into vectors, because iterating over
@@ -230,7 +230,7 @@ impl Command {
                 setns_namespaces: &setns_ns,
             };
             child::child_after_clone(&child_info);
-        }), &mut nstack[..], flags)));
+        }), &mut nstack[..], CloneFlags::from_bits(flags).unwrap())));
         drop(wakeup_rd);
         drop(errpipe_wr); // close pipe so we don't wait for ourself
 


### PR DESCRIPTION
Hello @tailhook. 
This crate fails to compile on aarch64 for two reasons: 

- nix 0.4.2
- using the integer type specific to x86_64 instead of the type provided by libc which is meant to abstract over platform differences.  

I changed nix's version to 0.5.1; I could have gone further but this is the minimal change necessary for the port. 

The unwrap should be as safe as the original function that took a number. If there is no corresponding flag, it fails.