### PR TITLE
stop CloneFlags implementation leak

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -134,7 +134,7 @@ impl Command {
         -> &mut Command
     {
         for ns in iter {
-            self.config.namespaces |= ns.to_clone_flag().bits();
+            self.config.namespaces |= ns.to_clone_flag();
         }
         self
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,5 +1,5 @@
 use nix::sched as consts;
-
+use libc::c_int;
 
 /// Namespace name to unshare
 ///
@@ -64,15 +64,18 @@ pub enum Namespace {
 
 impl Namespace {
     /// Convert namespace to a clone flag passed to syscalls
-    // TODO(tailhook) should this method be private?
-    pub fn to_clone_flag(&self) -> consts::CloneFlags {
-        match *self {
-            Namespace::Mount => consts::CLONE_NEWNS,
-            Namespace::Uts => consts::CLONE_NEWUTS,
-            Namespace::Ipc => consts::CLONE_NEWIPC,
-            Namespace::User => consts::CLONE_NEWUSER,
-            Namespace::Pid => consts::CLONE_NEWPID,
-            Namespace::Net => consts::CLONE_NEWNET,
-        }
+    pub fn to_clone_flag(&self) -> c_int {
+        clone_flag(self).bits()
+    }
+}
+
+pub fn clone_flag(ns: &Namespace) -> consts::CloneFlags {
+    match *ns {
+        Namespace::Mount => consts::CLONE_NEWNS,
+        Namespace::Uts => consts::CLONE_NEWUTS,
+        Namespace::Ipc => consts::CLONE_NEWIPC,
+        Namespace::User => consts::CLONE_NEWUSER,
+        Namespace::Pid => consts::CLONE_NEWPID,
+        Namespace::Net => consts::CLONE_NEWNET,
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -20,6 +20,7 @@ use nix::sys::wait::waitpid;
 use nix::unistd::{setpgid};
 
 use child;
+use namespace::clone_flag;
 use config::Config;
 use {Command, Child, ExitStatus};
 use error::{Error, result, cmd_result};
@@ -210,7 +211,7 @@ impl Command {
         let fds = int_fds.iter().map(|(&x, &y)| (x, y)).collect::<Vec<_>>();
         let close_fds = self.close_fds.iter().cloned().collect::<Vec<_>>();
         let setns_ns = self.config.setns_namespaces.iter()
-            .map(|(ns, fd)| (ns.to_clone_flag(), fd.as_raw_fd()))
+            .map(|(ns, fd)| (clone_flag(ns), fd.as_raw_fd()))
             .collect::<Vec<_>>();
         let pid = try!(result(Err::Fork, clone(Box::new(|| -> isize {
             // Note: mo memory allocations/deallocations here


### PR DESCRIPTION
Hello @tailhook,

As you noted in #8,  the changes I made caused `CloneFlags` to be exposed outside of the library.  To solve that I made a free function so it could be public within the library, and made `to_clone_flags` return `c_int` Instead. 