### PR TITLE
Add missing functionality from removed api

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -153,7 +153,7 @@ impl Command {
     pub fn set_namespace<F: AsRawFd>(&mut self, file: &F, ns: Namespace)
         -> io::Result<&mut Command>
     {
-        let fd = try!(dup_file_cloexec(file));
+        let fd = try!(dup_file_cloexec(file.as_raw_fd()));
         self.config.setns_namespaces.insert(ns, fd);
         Ok(self)
     }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,4 +1,5 @@
 use nix::sched as consts;
+use libc::c_int;
 
 
 /// Namespace name to unshare
@@ -68,8 +69,13 @@ pub enum Namespace {
     Cgroup,
 }
 
-/// Convert namespace to a clone flag passed to syscalls
-// TODO(tailhook) should this method be private?
+impl Namespace {
+    /// Convert namespace to a clone flag passed to syscalls
+    pub fn clone_flag(&self) -> c_int {
+    to_clone_flag(*self).bits()
+    }
+}
+
 pub fn to_clone_flag(ns: Namespace) -> consts::CloneFlags {
     match ns {
         Namespace::Mount => consts::CLONE_NEWNS,


### PR DESCRIPTION
Hi @tailhook, 
While you did remove the implementation leak from `to_clone_flags` and the unsafe `from_raw_fd`,  there wasn't anything left in unshare to allow the library's users to pass the `CloneFlags` to syscalls from a `Namespace`  or create a `Stdio` object directly from a `RawFd` respectively.
This PR attempts to fix that.