### PR TITLE
Add envs method to Command

### DIFF
--- a/src/std_api.rs
+++ b/src/std_api.rs
@@ -83,12 +83,16 @@ impl Command {
         self
     }
 
-    /// Inserts or updates an environment variable mapping.
+    /// Inserts or updates multiple environment variable mappings.
     pub fn envs<I, K, V>(&mut self, vars: I)-> &mut Command
         where I: IntoIterator<Item=(K, V)>, K: AsRef<OsStr>, V: AsRef<OsStr>
     {
         for (ref key, ref val) in vars {
-            self.inner.env_mut().set(key.as_ref(), val.as_ref());
+            self.init_env_map();
+            self.environ.as_mut().unwrap().insert(
+                key.as_ref().to_os_string(),
+                val.as_ref().to_os_string());
+            self.pid_env_vars.remove(key.as_ref());
         }
         self
     }


### PR DESCRIPTION
Adds a convenience method envs for adding multiple environment variables at once. Lifted directly from the stdlib.