### PR TITLE
Make before_unfreeze and before_exec return self for chaining

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -11,7 +11,7 @@ impl Command {
     /// process (child) by privileged process (parent).
     ///
     /// This callback runs in **parent** process after all built-in setup is
-    /// done (setting uid namespaces). It always run before ``before_exec``
+    /// done (setting uid namespaces). It always run before ``pre_exec``
     /// callback in child.
     ///
     /// If callback returns error, process is shut down.
@@ -44,11 +44,11 @@ impl Command {
     /// Note: unlike same method in stdlib,
     /// each invocation of this method **replaces** callback,
     /// so there is only one of them can be called.
-    pub fn before_exec(
+    pub unsafe fn pre_exec(
         &mut self,
         f: impl Fn() -> io::Result<()> + Send + Sync + 'static,
     ) -> &mut Self {
-        self.before_exec = Some(Box::new(f));
+        self.pre_exec = Some(Box::new(f));
         self
     }
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -19,10 +19,12 @@ impl Command {
     /// Each invocation **replaces** callback,
     /// so there is only one of them can be called.
     ///
-    pub fn before_unfreeze(&mut self,
-        f: impl FnMut(u32) -> Result<(), BoxError> + 'static)
-    {
+    pub fn before_unfreeze(
+        &mut self,
+        f: impl FnMut(u32) -> Result<(), BoxError> + 'static,
+    ) -> &mut Self {
         self.before_unfreeze = Some(Box::new(f));
+        self
     }
 
     /// Set a callback to run in the child before calling exec
@@ -42,9 +44,11 @@ impl Command {
     /// Note: unlike same method in stdlib,
     /// each invocation of this method **replaces** callback,
     /// so there is only one of them can be called.
-    pub fn before_exec(&mut self,
-        f: impl Fn() -> io::Result<()> + Send + Sync + 'static)
-    {
+    pub fn before_exec(
+        &mut self,
+        f: impl Fn() -> io::Result<()> + Send + Sync + 'static,
+    ) -> &mut Self {
         self.before_exec = Some(Box::new(f));
+        self
     }
 }

--- a/src/child.rs
+++ b/src/child.rs
@@ -215,9 +215,9 @@ pub unsafe fn child_after_clone(child: &ChildInfo) -> ! {
         }
     }
 
-    if let Some(callback) = child.before_exec {
+    if let Some(callback) = child.pre_exec {
         if let Err(e) = callback() {
-            fail_errno(Err::BeforeExec,
+            fail_errno(Err::PreExec,
                 e.raw_os_error().unwrap_or(10873289),
                 epipe);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ pub enum ErrorCode {
     SetPGid = 11,
     SetNs = 12,
     CapSet = 13,
-    BeforeExec = 14,
+    PreExec = 14,
 }
 
 /// Error runnning process
@@ -93,7 +93,7 @@ pub enum Error {
     /// Before unfreeze callback error
     BeforeUnfreeze(Box<::std::error::Error + Send + Sync + 'static>),
     /// Before exec callback error
-    BeforeExec(i32),
+    PreExec(i32),
 }
 
 impl Error {
@@ -120,7 +120,7 @@ impl Error {
             &SetNs(x) => Some(x),
             &CapSet(x) => Some(x),
             &BeforeUnfreeze(..) => None,
-            &BeforeExec(x) => Some(x),
+            &PreExec(x) => Some(x),
         }
     }
 }
@@ -148,7 +148,7 @@ impl StdError for Error {
             &SetNs(_) => "error when calling setns",
             &CapSet(_) => "error when setting capabilities",
             &BeforeUnfreeze(_) => "error in before_unfreeze callback",
-            &BeforeExec(_) => "error in before_exec callback",
+            &PreExec(_) => "error in pre_exec callback",
         }
     }
 }
@@ -240,7 +240,7 @@ impl ErrorCode {
             C::SetPGid => E::SetPGid(errno),
             C::SetNs => E::SetNs(errno),
             C::CapSet => E::CapSet(errno),
-            C::BeforeExec => E::BeforeExec(errno),
+            C::PreExec => E::PreExec(errno),
         }
     }
     pub fn from_i32(code: i32, errno: i32) -> Error {
@@ -262,7 +262,7 @@ impl ErrorCode {
             c if c == C::SetNs as i32 => E::SetNs(errno),
             c if c == C::CapSet as i32 => E::CapSet(errno),
             // no BeforeUnfreeze, because can't be in a child
-            c if c == C::BeforeExec as i32 => E::BeforeExec(errno),
+            c if c == C::PreExec as i32 => E::PreExec(errno),
             _ => E::UnknownError,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub struct Command {
     pid_env_vars: HashSet<OsString>,
     keep_caps: Option<[u32; 2]>,
     before_unfreeze: Option<Box<FnMut(u32) -> Result<(), BoxError>>>,
-    before_exec: Option<Box<Fn() -> Result<(), io::Error>>>,
+    pre_exec: Option<Box<Fn() -> Result<(), io::Error>>>,
 }
 
 /// The reference to the running child

--- a/src/run.rs
+++ b/src/run.rs
@@ -51,7 +51,7 @@ pub struct ChildInfo<'a> {
     pub setns_namespaces: &'a [(CloneFlags, RawFd)],
     pub pid_env_vars: &'a [(usize, usize)],
     pub keep_caps: &'a Option<[u32; 2]>,
-    pub before_exec: &'a Option<Box<Fn() -> Result<(), io::Error>>>,
+    pub pre_exec: &'a Option<Box<Fn() -> Result<(), io::Error>>>,
 }
 
 fn raw_with_null(arr: &Vec<CString>) -> Vec<*const c_char> {
@@ -257,7 +257,7 @@ impl Command {
                 setns_namespaces: &setns_ns,
                 pid_env_vars: &pid_env_vars,
                 keep_caps: &self.keep_caps,
-                before_exec: &self.before_exec,
+                pre_exec: &self.pre_exec,
             };
             child::child_after_clone(&child_info);
         }), &mut nstack[..], self.config.namespaces, Some(SIGCHLD as i32))));

--- a/src/std_api.rs
+++ b/src/std_api.rs
@@ -46,7 +46,7 @@ impl Command {
             pid_env_vars: HashSet::new(),
             keep_caps: None,
             before_unfreeze: None,
-            before_exec: None,
+            pre_exec: None,
         }
     }
 


### PR DESCRIPTION
Since we're changing the API anyway to return self, switch `before_exec`
to unsafe like the standard library's equivalent did, and rename it to
`pre_exec` accordingly. Rename the related error and field to match, to
avoid confusion.