### PR TITLE
Upgrade Cargo dependencies; fix build on aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ version = "0.6.0"
 authors = ["paul@colomiets.name"]
 
 [dependencies]
-libc = "0.2.26"
-nix = "0.11.0"
+libc = "0.2.93"
+nix = "0.20.0"
 
 [dev-dependencies]
-argparse = "0.2.1"
-rand = "0.4.2"
+argparse = "0.2.2"
+rand = "0.8.3"
 
 [lib]
 name = "unshare"


### PR DESCRIPTION
Upgrading nix avoids a build error on aarch64, caused by assuming that
MAP_32BIT exists.