### PR TITLE
setgroups < deny is needed before group ids are set

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum ErrorCode {
     SetNs = 12,
     CapSet = 13,
     PreExec = 14,
+    SetGroupsDeny = 15,
 }
 
 /// Error runnning process
@@ -93,6 +94,8 @@ pub enum Error {
     BeforeUnfreeze(Box<dyn (::std::error::Error) + Send + Sync + 'static>),
     /// Before exec callback error
     PreExec(i32),
+    /// Writing /proc/self/setgroups < deny failed
+    SetGroupsDeny(i32)
 }
 
 impl Error {
@@ -120,6 +123,7 @@ impl Error {
             &CapSet(x) => Some(x),
             &BeforeUnfreeze(..) => None,
             &PreExec(x) => Some(x),
+            &SetGroupsDeny(x) => Some(x),
         }
     }
 }
@@ -148,6 +152,7 @@ impl Error {
             &CapSet(_) => "error when setting capabilities",
             &BeforeUnfreeze(_) => "error in before_unfreeze callback",
             &PreExec(_) => "error in pre_exec callback",
+            &SetGroupsDeny(_) => "error setting /proc/self/setgroups < deny"
         }
     }
 }
@@ -240,6 +245,7 @@ impl ErrorCode {
             C::SetNs => E::SetNs(errno),
             C::CapSet => E::CapSet(errno),
             C::PreExec => E::PreExec(errno),
+            C::SetGroupsDeny => E::SetGroupsDeny(errno),
         }
     }
     pub fn from_i32(code: i32, errno: i32) -> Error {

--- a/src/run.rs
+++ b/src/run.rs
@@ -334,6 +334,14 @@ impl Command {
                 result(Err::SetIdMap,
                     File::create(format!("/proc/{}/uid_map", pid))
                     .and_then(|mut f| f.write_all(&buf[..])))?;
+
+
+                let buf = "deny".as_bytes();
+
+                result(Err::SetGroupsDeny,
+                    File::create(format!("/proc/{}/setgroups", pid))
+                    .and_then(|mut f| f.write_all(&buf[..])))?;
+
                 let mut buf = Vec::new();
                 for map in gids {
                     writeln!(&mut buf, "{} {} {}",


### PR DESCRIPTION
Since Linux 3.19 unprivileged writing of /proc/self/gid_map has been disabled unless /proc/self/setgroups is written first to permanently disable the ability to call setgroups in that user namespace.

This essentially means we need to write "deny" to /proc/self/setgroups. This PR adds that one invocation. 

Without this, you can't map a child in CLONE_NEWUSER uid 0 and gid 0 to an unprivileged caller's uid and gid.