### PR TITLE
Implement str::error::Error trait for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -177,6 +177,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[inline]
 pub fn result<T, E: IntoError>(code: ErrorCode, r: Result<T, E>)
     -> Result<T, Error>


### PR DESCRIPTION
`unshare::Error` doesn't implement `std::error:Error`, making it difficult to use with crates like `anyhow` for exemple.
This fixes that 😄