### PR TITLE
Add support for rlimits

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 use libc;
 use nix;
-use libc::{c_void, c_ulong, sigset_t, size_t};
+use libc::{c_void, c_ulong, sigset_t, size_t, rlimit};
 use libc::{kill, signal};
 use libc::{F_GETFD, F_SETFD, F_DUPFD_CLOEXEC, FD_CLOEXEC, MNT_DETACH};
 use libc::{SIG_DFL, SIG_SETMASK};
@@ -212,6 +212,13 @@ pub unsafe fn child_after_clone(child: &ChildInfo) -> ! {
         libc::pthread_sigmask(SIG_SETMASK, &sigmask, ptr::null_mut());
         for sig in 1..32 {
             signal(sig, SIG_DFL);
+        }
+    }
+
+    for &(rlim_type, rlim_value) in child.rlimits {
+        let limit = rlimit{rlim_cur: rlim_value, rlim_max: rlim_value};
+        if libc::setrlimit(rlim_type, &limit) < 0 {
+            fail(Err::RLimit, epipe);
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum ErrorCode {
     SetNs = 12,
     CapSet = 13,
     PreExec = 14,
+    RLimit = 16,
 }
 
 /// Error runnning process
@@ -93,6 +94,8 @@ pub enum Error {
     BeforeUnfreeze(Box<dyn (::std::error::Error) + Send + Sync + 'static>),
     /// Before exec callback error
     PreExec(i32),
+    /// Error when calling setrlimit syscall
+    SetRLimit(i32),
 }
 
 impl Error {
@@ -120,6 +123,7 @@ impl Error {
             &CapSet(x) => Some(x),
             &BeforeUnfreeze(..) => None,
             &PreExec(x) => Some(x),
+            &SetRLimit(x) => Some(x),
         }
     }
 }
@@ -148,6 +152,7 @@ impl Error {
             &CapSet(_) => "error when setting capabilities",
             &BeforeUnfreeze(_) => "error in before_unfreeze callback",
             &PreExec(_) => "error in pre_exec callback",
+            &SetRLimit(_) => "error setting rlimit",
         }
     }
 }
@@ -240,6 +245,7 @@ impl ErrorCode {
             C::SetNs => E::SetNs(errno),
             C::CapSet => E::CapSet(errno),
             C::PreExec => E::PreExec(errno),
+            C::RLimit => E::SetRLimit(errno),
         }
     }
     pub fn from_i32(code: i32, errno: i32) -> Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub struct Command {
     id_map_commands: Option<(PathBuf, PathBuf)>,
     pid_env_vars: HashSet<OsString>,
     keep_caps: Option<[u32; 2]>,
+    rlimits: Vec<(libc::__rlimit_resource_t, libc::rlim_t)>,
     before_unfreeze: Option<Box<dyn FnMut(u32) -> Result<(), BoxError>>>,
     pre_exec: Option<Box<dyn Fn() -> Result<(), io::Error>>>,
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::io;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-
+use libc::{__rlimit_resource_t, rlim_t};
 use nix::sys::signal::{Signal};
 
 use crate::ffi_util::ToCString;
@@ -292,5 +292,13 @@ impl Command {
             buf[(item >> 5) as usize] |= 1 << (item & 31);
         }
         self.keep_caps = Some(buf);
+    }
+
+    /// Set resource limits (rlimit / ulimit)
+    pub fn set_rlimit(&mut self, resource: __rlimit_resource_t, limit: rlim_t)
+        -> &mut Command
+    {
+        self.rlimits.push((resource, limit));
+        self
     }
 }

--- a/src/std_api.rs
+++ b/src/std_api.rs
@@ -46,6 +46,7 @@ impl Command {
             pid_env_vars: HashSet::new(),
             keep_caps: None,
             before_unfreeze: None,
+            rlimits: Vec::new(),
             pre_exec: None,
         }
     }


### PR DESCRIPTION
This PR adds resource constraints to the child process, using `setrlimit`.

Example usage:
```rust
use nix::libc::{RLIMIT_AS, RLIMIT_CPU, RLIMIT_NICE, RLIMIT_NOFILE, RLIMIT_NPROC, RLIMIT_RSS};

cmd.set_rlimit(RLIMIT_NOFILE, 10);
cmd.set_rlimit(RLIMIT_CPU, 1);
cmd.set_rlimit(RLIMIT_NPROC, 3);
cmd.set_rlimit(RLIMIT_AS, 64 * 1024 * 1024);
cmd.set_rlimit(RLIMIT_RSS, 64 * 1024 * 1024);
cmd.set_rlimit(RLIMIT_NICE, 0);
```

---
**Availability:** If anyone wants to use this and other features before it's merged, check out [my temporary fork](https://github.com/MarkusBauer/unshare). It includes #23 #27 #29 #33 #34 #35 and #36 with all conflicts resolved.
Add to your `Cargo.toml`: `unshare = { git = "https://github.com/MarkusBauer/unshare.git" }`