### PR TITLE
Add fakeroot - combined mount and chroot to create a docker-like view on the filesystem

### DIFF
--- a/examples/fakeroot.rs
+++ b/examples/fakeroot.rs
@@ -13,6 +13,8 @@ fn main() {
     cmd.fakeroot_mount("/etc", "/etc", true);
     cmd.fakeroot_mount("/lib", "/lib", true);
     cmd.fakeroot_mount("/lib64", "/lib64", true);
+    cmd.fakeroot_filesystem("proc", "/proc");
+    cmd.fakeroot_filesystem("tmpfs", "/tmp");
     cmd.fakeroot_mount("/usr", "/usr", true);
     cmd.current_dir("/");
 

--- a/examples/fakeroot.rs
+++ b/examples/fakeroot.rs
@@ -1,0 +1,24 @@
+extern crate unshare;
+
+use std::process::exit;
+
+
+fn main() {
+    let mut cmd = unshare::Command::new("/usr/bin/ls");
+    cmd.arg("-l");
+    cmd.arg("/");
+
+    cmd.fakeroot_enable("/dev/shm/sandbox_root");
+    cmd.fakeroot_mount("/bin", "/bin", true);
+    cmd.fakeroot_mount("/etc", "/etc", true);
+    cmd.fakeroot_mount("/lib", "/lib", true);
+    cmd.fakeroot_mount("/lib64", "/lib64", true);
+    cmd.fakeroot_mount("/usr", "/usr", true);
+    cmd.current_dir("/");
+
+    match cmd.status().unwrap() {
+        // propagate signal
+        unshare::ExitStatus::Exited(x) => exit(x as i32),
+        unshare::ExitStatus::Signaled(x, _) => exit((128+x as i32) as i32),
+    }
+}

--- a/examples/fakeroot.rs
+++ b/examples/fakeroot.rs
@@ -10,6 +10,7 @@ fn main() {
 
     cmd.fakeroot_enable("/dev/shm/sandbox_root");
     cmd.fakeroot_mount("/bin", "/bin", true);
+    cmd.fakeroot_mount_file("/dev/urandom", "/dev/urandom", false);
     cmd.fakeroot_mount("/etc", "/etc", true);
     cmd.fakeroot_mount("/lib", "/lib", true);
     cmd.fakeroot_mount("/lib64", "/lib64", true);

--- a/src/child.rs
+++ b/src/child.rs
@@ -145,7 +145,10 @@ pub unsafe fn child_after_clone(child: &ChildInfo) -> ! {
     });
 
     child.cfg.fake_root_base.as_ref().map(|base| {
-        if !build_fakeroot(base, child.cfg.fake_root_mounts.as_ref()) {
+        if !build_fakeroot(base,
+                           child.cfg.fake_root_mkdirs.as_ref(),
+                           child.cfg.fake_root_touchs.as_ref(),
+                           child.cfg.fake_root_mounts.as_ref()) {
             fail(Err::ChangeRoot, epipe);
         }
     });

--- a/src/child.rs
+++ b/src/child.rs
@@ -145,7 +145,7 @@ pub unsafe fn child_after_clone(child: &ChildInfo) -> ! {
     });
 
     child.cfg.fake_root_base.as_ref().map(|base| {
-        if !build_fakeroot(base, child.cfg.fake_root_proc.as_ref(), child.cfg.fake_root_mounts.as_ref()) {
+        if !build_fakeroot(base, child.cfg.fake_root_mounts.as_ref()) {
             fail(Err::ChangeRoot, epipe);
         }
     });

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     // TODO(tailhook) session leader
     pub fake_root_base: Option<CString>,
     pub fake_root_mounts: Vec<FakeRootMount>,
+    pub fake_root_mkdirs: Vec<CString>,
+    pub fake_root_touchs: Vec<CString>,
 }
 
 impl Default for Config {
@@ -43,6 +45,8 @@ impl Default for Config {
             make_group_leader: false,
             fake_root_base: None,
             fake_root_mounts: Vec::new(),
+            fake_root_mkdirs: Vec::new(),
+            fake_root_touchs: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use nix::sys::signal::{Signal, SIGKILL};
 use nix::sched::CloneFlags;
 use libc::{uid_t, gid_t};
 
+use crate::fakeroot::{FakeRootMount};
 use crate::idmap::{UidMap, GidMap};
 use crate::namespace::Namespace;
 use crate::stdio::Closing;
@@ -23,6 +24,9 @@ pub struct Config {
     pub restore_sigmask: bool,
     pub make_group_leader: bool,
     // TODO(tailhook) session leader
+    pub fake_root_base: Option<CString>,
+    pub fake_root_proc: Option<CString>,
+    pub fake_root_mounts: Vec<FakeRootMount>,
 }
 
 impl Default for Config {
@@ -38,6 +42,9 @@ impl Default for Config {
             setns_namespaces: HashMap::new(),
             restore_sigmask: true,
             make_group_leader: false,
+            fake_root_base: None,
+            fake_root_mounts: Vec::new(),
+            fake_root_proc: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,6 @@ pub struct Config {
     pub make_group_leader: bool,
     // TODO(tailhook) session leader
     pub fake_root_base: Option<CString>,
-    pub fake_root_proc: Option<CString>,
     pub fake_root_mounts: Vec<FakeRootMount>,
 }
 
@@ -44,7 +43,6 @@ impl Default for Config {
             make_group_leader: false,
             fake_root_base: None,
             fake_root_mounts: Vec::new(),
-            fake_root_proc: None,
         }
     }
 }

--- a/src/fakeroot.rs
+++ b/src/fakeroot.rs
@@ -1,0 +1,140 @@
+use crate::ffi_util::ToCString;
+use crate::{Command, Namespace};
+use libc::{MNT_DETACH, MS_BIND, MS_PRIVATE, MS_RDONLY, MS_REC, MS_REMOUNT};
+use std::ffi::{c_char, c_void, CString};
+use std::path::Path;
+
+pub struct FakeRootMount {
+    mountpoint: CString,
+    mountpoint_outer: CString,
+    src: CString,
+    readonly: bool,
+}
+
+impl Command {
+    /// Enable "fakeroot" - the command will be rooted in a custom root directory.
+    ///
+    /// By default, the root directory is empty, share necessary directories with fakeroot_mount().
+    /// This will automatically unshare the mount namespace.
+    /// It might be necessary to also unshare the user namespace.
+    ///
+    /// The "base" directory must be an empty directory, preferably on a tmpfs.
+    /// The directory will be created if missing.
+    /// "/dev/shm/unshare_root" should work fine, or "/run/user/<uid>/unshare_root".
+    ///
+    /// Do NOT combine with manual pivot_root/chroot, fakeroot will take care of it.
+    pub fn fakeroot_enable(&mut self, base: &str) {
+        self.unshare(&[Namespace::Mount]);
+        self.config.fake_root_base = Some(base.to_cstring());
+        self.config.fake_root_proc = Some(format!("{}/proc", base).to_cstring());
+    }
+
+    /// Add an existing directory to the fakeroot.
+    ///
+    /// fakeroot_enable() must be called first, otherwise this function will panic.
+    ///
+    /// Example usage:
+    ///   cmd.fakeroot_mount("/bin", "/bin", true);
+    ///   cmd.fakeroot_mount("/etc", "/etc", true);
+    ///   cmd.fakeroot_mount("/lib", "/lib", true);
+    ///   cmd.fakeroot_mount("/lib64", "/lib64", true);
+    ///   cmd.fakeroot_mount("/usr", "/usr", true);
+    pub fn fakeroot_mount<P: AsRef<Path>>(&mut self, src: P, dst: &str, readonly: bool) {
+        let base = self
+            .config
+            .fake_root_base
+            .as_ref()
+            .expect("call fakeroot_enable() first!")
+            .to_str()
+            .unwrap();
+        self.config.fake_root_mounts.push(FakeRootMount {
+            mountpoint: dst.to_cstring(),
+            mountpoint_outer: format!("{}/{}", base, dst).to_cstring(),
+            src: src.as_ref().to_cstring(),
+            readonly,
+        });
+    }
+}
+
+/// This syscall sequence is more or less taken from nsjail (https://github.com/google/nsjail).
+pub(crate) unsafe fn build_fakeroot(
+    base: &CString,
+    proc: Option<&CString>,
+    mountpoints: &[FakeRootMount],
+) -> bool {
+    // define some libc constants
+    let null_char = 0 as *const c_char;
+    let null_void = 0 as *const c_void;
+    let slash = b"/\0".as_ptr() as *const c_char;
+    let dot = b".\0".as_ptr() as *const c_char;
+    let tmpfs = b"tmpfs\0".as_ptr() as *const c_char;
+    let procfs = b"proc\0".as_ptr() as *const c_char;
+
+    // keep all mount changes private
+    libc::mkdir(base.as_ptr(), 0o777);
+    if libc::mount(slash, slash, null_char, MS_PRIVATE | MS_REC, null_void) < 0 {
+        return false;
+    }
+
+    // create fakeroot filesystem
+    if libc::mount(null_char, base.as_ptr(), tmpfs, 0, null_void) < 0 {
+        return false;
+    }
+
+    // mount directories - still read-write (because MS_BIND + MS_RDONLY are not supported)
+    for mount in mountpoints {
+        libc::mkdir(mount.mountpoint_outer.as_ptr(), 0o777);
+        if libc::mount(
+            mount.src.as_ptr(),
+            mount.mountpoint_outer.as_ptr(),
+            null_char,
+            MS_PRIVATE | MS_REC | MS_BIND,
+            null_void,
+        ) < 0
+        {
+            return false;
+        }
+    }
+
+    // mount new "/proc" (if available, for example: not in docker). No error if failing.
+    proc.map(|proc| {
+        libc::mkdir(proc.as_ptr(), 0o777);
+        libc::mount(null_char, proc.as_ptr(), procfs, 0, null_void);
+    });
+
+    // chroot jail (try pivot_root first, use classic chroot if not available)
+    if libc::syscall(libc::SYS_pivot_root, base.as_ptr(), base.as_ptr()) >= 0 {
+        libc::umount2(slash, MNT_DETACH);
+    } else {
+        libc::chdir(base.as_ptr());
+        libc::mount(dot, slash, null_char, 0, null_void);
+        if libc::chroot(dot) < 0 {
+            return false;
+        }
+    }
+
+    // make directories actually read-only
+    libc::mount(
+        slash,
+        slash,
+        null_char,
+        MS_REMOUNT | MS_BIND | MS_RDONLY,
+        null_void,
+    );
+    for mount in mountpoints {
+        if mount.readonly {
+            if libc::mount(
+                mount.mountpoint.as_ptr(),
+                mount.mountpoint.as_ptr(),
+                null_char,
+                MS_REMOUNT | MS_BIND | MS_RDONLY,
+                null_void,
+            ) < 0
+            {
+                return false;
+            }
+        }
+    }
+
+    true
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod wait;
 mod stdio;
 mod debug;
 mod zombies;
+mod fakeroot;
 
 pub use crate::error::Error;
 pub use crate::status::ExitStatus;


### PR DESCRIPTION
While this project already has support for chroot and pivot_root, these features are hardly useful if you want to start anything else than a static linked binary. Thus I added a more powerful feature: fakeroots. 

A fakeroot is an initially empty root, where directories from the host can be selectively shared. Shares can be read-only if necessary, providing additional isolation. For example, this code allows read-only access to installed programs but not user data and no write access at all:
```rust
cmd.fakeroot_enable("/dev/shm/sandbox_root");
cmd.fakeroot_mount("/bin", "/bin", true);  // add directories
cmd.fakeroot_mount_file("/dev/urandom", "/dev/urandom", false);  // add files/devices
cmd.fakeroot_mount("/etc", "/etc", true);
cmd.fakeroot_mount("/lib", "/lib", true);
cmd.fakeroot_mount("/lib64", "/lib64", true);
cmd.fakeroot_filesystem("proc", "/proc");  // add custom filesystems (proc or tmpfs)
cmd.fakeroot_filesystem("tmpfs", "/tmp");
cmd.fakeroot_mount("/usr", "/usr", true);
```

The implementation is mostly inspired by [nsjail](https://github.com/google/nsjail) which uses the same syscall sequence.
Supported are: directories, files, devices, and custom filesystems like `proc` or `tmp`.

---
**Availability:** If anyone wants to use this and other features before it's merged, check out [my temporary fork](https://github.com/MarkusBauer/unshare). It includes #23 #27 #29 #33 #34 #35 and #36 with all conflicts resolved.
Add to your `Cargo.toml`: `unshare = { git = "https://github.com/MarkusBauer/unshare.git" }`